### PR TITLE
feat: Create schema folder with marks and nodes

### DIFF
--- a/.changeset/large-rivers-knock.md
+++ b/.changeset/large-rivers-knock.md
@@ -1,0 +1,5 @@
+---
+"@cultureamp/rich-text-toolkit": minor
+---
+
+Creates schema folder with nodes and marks

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/prosemirror-history": "^1.0.3",
     "@types/prosemirror-model": "^1.16.1",
     "@types/prosemirror-state": "^1.2.8",
+    "@types/prosemirror-schema-basic": "^1.0.2",
     "@types/prosemirror-view": "^1.23.1",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
@@ -65,6 +66,7 @@
     "prosemirror-history": "^1.2.0",
     "prosemirror-model": "^1.16.1",
     "prosemirror-state": "^1.3.4",
-    "prosemirror-view": "^1.23.7"
+    "prosemirror-view": "^1.23.7",
+    "prosemirror-schema-basic": "^1.1.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./core/index.js"
+export * from "./schema/index.js"

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,2 @@
+export * from "./marks.js"
+export * from "./nodes.js"

--- a/src/schema/marks.ts
+++ b/src/schema/marks.ts
@@ -1,0 +1,15 @@
+import { MarkSpec } from "prosemirror-model"
+import { marks as proseMarks } from "prosemirror-schema-basic"
+
+export const marks: MarkSpec = {
+  ...proseMarks,
+
+  // An underline mark. Rendered as a `<u>` element. Has parse rules that also
+  // matches `font-style: underline`.
+  underline: {
+    parseDOM: [{ tag: "u" }, { style: "font-style=underline" }],
+    toDOM() {
+      return ["u", 0]
+    },
+  },
+}

--- a/src/schema/nodes.ts
+++ b/src/schema/nodes.ts
@@ -1,0 +1,6 @@
+import { NodeSpec } from "prosemirror-model"
+import { nodes as proseNodes } from "prosemirror-schema-basic"
+
+export const nodes: NodeSpec = {
+  ...proseNodes,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,6 +979,13 @@
   dependencies:
     "@types/orderedmap" "*"
 
+"@types/prosemirror-schema-basic@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/prosemirror-schema-basic/-/prosemirror-schema-basic-1.0.2.tgz#d6ba0f9e1dd054a312ff6fbf5b38e10b067c3d66"
+  integrity sha512-dzT/6t+dq8/On1be0yarcOIu8wROjhK8QB5wslpLbtTIr5wb0iQv/esJm/KAHcD/PBXR9nSV4TL5AtQmBrcRnw==
+  dependencies:
+    "@types/prosemirror-model" "*"
+
 "@types/prosemirror-state@*", "@types/prosemirror-state@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@types/prosemirror-state/-/prosemirror-state-1.2.8.tgz#65080eeec52f63c50bf7034377f07773b4f6b2ac"
@@ -3740,12 +3747,19 @@ prosemirror-history@^1.2.0:
     prosemirror-transform "^1.0.0"
     rope-sequence "^1.3.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.16.1:
+prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.16.1, prosemirror-model@^1.2.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.16.1.tgz#fb388270bc9609b66298d6a7e15d0cc1d6c61253"
   integrity sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==
   dependencies:
     orderedmap "^1.1.0"
+
+prosemirror-schema-basic@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-schema-basic/-/prosemirror-schema-basic-1.1.2.tgz#4bde5c339c845e0d08ec8fe473064e372ca51ae3"
+  integrity sha512-G4q8WflNsR1Q33QAV4MQO0xWrHLOJ+BQcKswGXMy626wlQj6c/1n1v4eC9ns+h2y1r/fJHZEgSZnsNhm9lbrDw==
+  dependencies:
+    prosemirror-model "^1.2.0"
 
 prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
Creates a place to grab common nodes and marks for creating a schema.

Mainly just shims over https://github.com/ProseMirror/prosemirror-schema-basic/blob/master/src/schema-basic.js for now, but gives us a place to add more things, like I've done with underline.