### PR TITLE
Expand supported node versions to v14 and above

### DIFF
--- a/.changeset/shiny-peas-happen.md
+++ b/.changeset/shiny-peas-happen.md
@@ -1,0 +1,5 @@
+---
+"@cultureamp/rich-text-toolkit": minor
+---
+
+Expand supported node versions to v14 and above

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "@changesets/cli": "^2.21.0",
     "@cultureamp/changelog-github": "^0.1.0",
     "@testing-library/react": "^12.1.3",
-    "@tsconfig/node16": "^1.0.2",
+    "@tsconfig/node14": "^1.0.1",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
     "@types/prosemirror-commands": "^1.0.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
     "declaration": true,
     "declarationMap": true,
-    "lib": ["dom", "es2021"],
+    "lib": ["dom", "es2020"],
     "module": "es2020",
     "moduleResolution": "node",
     "outDir": "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,10 +826,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsconfig/node16@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
-  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+"@tsconfig/node14@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
 "@types/aria-query@^4.2.0":
   version "4.2.2"


### PR DESCRIPTION
The kaizen-design-system repo (at time of writing) still builds using node v14. This change updates the compiler config to support node v14 and above.