### PR TITLE
Publish both CommonJS and ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semi": false
   },
   "scripts": {
-    "build": "tsc --outDir dist/cjs --module CommonJS && tsc --outDir dist/mjs && yarn copy-files",
+    "build": "tsc --outDir dist/cjs --module CommonJS && tsc --outDir dist/mjs --module es2020 && yarn copy-files",
     "clean": "rm -rf dist",
     "copy-files": "copyfiles -u 1 src/**/*.scss dist/",
     "lint": "yarn lint:prettier --write && yarn lint:eslint --fix",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "node": ">=14"
   },
   "type": "module",
-  "main": "./dist/index.js",
+  "module": "./dist/mjs/index.js",
+  "main": "./dist/cjs/index.js",
   "files": [
     "dist/",
     "src/",
@@ -25,8 +26,8 @@
     "semi": false
   },
   "scripts": {
-    "build": "tsc --build && yarn copy-files",
-    "clean": "tsc --build --clean",
+    "build": "tsc --outDir dist/cjs --module CommonJS && tsc --outDir dist/mjs && yarn copy-files",
+    "clean": "rm -rf dist",
     "copy-files": "copyfiles -u 1 src/**/*.scss dist/",
     "lint": "yarn lint:prettier --write && yarn lint:eslint --fix",
     "lint-ci": "yarn lint:prettier --check && yarn lint:eslint --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsc --outDir dist/cjs --module CommonJS && tsc --outDir dist/mjs --module es2020 && yarn copy-files",
     "clean": "rm -rf dist",
-    "copy-files": "copyfiles -u 1 src/**/*.scss dist/",
+    "copy-files": "copyfiles -u 1 src/**/*.scss dist/cjs && copyfiles -u 1 src/**/*.scss dist/mjs",
     "lint": "yarn lint:prettier --write && yarn lint:eslint --fix",
     "lint-ci": "yarn lint:prettier --check && yarn lint:eslint --max-warnings=0",
     "lint:eslint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
[We are having issues](https://cultureamp.slack.com/archives/C016N8Y1E10/p1656465954791289) with importing this package within Kaizen and using it with Jest _without tricks_; without making ts-jest transform the distributed JS within publications of this project.
This is because the published artifacts are targeting an ESM environment, which, as we know is a problem within CultureAmp (think about all the repos that have a `libsThatRequireBabel` concept...pretty much all of them).

I've assumed that there is a good reason for publishing an ESM style package, so this PR causes both ESM and CJS to be published.

The reason why we're not just using the _trick_ within Kaizen and moving on is because **everyone at CultureAmp**  who uses this package will have the same problem when using Jest.

This isn't a breaking change unless consumers were relying explicitly on the tree of the `dist/` directory or the `main` and `module` pointers within `package.json`; the API isn't changing so in theory it's not breaking, but in practice we might want to just bump the major to be safe.

This PR is also a request for comments in case I've neglected something, OR there is a giant misunderstanding and we've done something gravely wrong  😅

## Extra notes

I'm not really keen on the "additional tsconfig" file pattern, hence just changing the build scripts and using CLI args to modify TSC behavour, but, by all means, lets do that if it's preferred.