### PR TITLE
Make aria-labelledby optional on useRichTextEditor

### DIFF
--- a/.changeset/spicy-lions-grab.md
+++ b/.changeset/spicy-lions-grab.md
@@ -1,0 +1,5 @@
+---
+"@cultureamp/rich-text-toolkit": patch
+---
+
+Make aria-labelledby optional on useRichTextEditor

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -14,7 +14,9 @@ type EditorArgs = {
   /*
    * Pass in HTML attributes into the parent RTE node
    */
-  attributes: { "aria-labelledby": string; [name: string]: string }
+  attributes?: {
+    [name: string]: string
+  }
   isEditable?: () => boolean
 }
 

--- a/src/core/hooks/useRichTextEditor.ts
+++ b/src/core/hooks/useRichTextEditor.ts
@@ -29,7 +29,9 @@ export function useRichTextEditor(
   /*
    * Pass in HTML attributes into the parent RTE node
    */
-  attributes: { "aria-labelledby": string; [name: string]: string },
+  attributes?: {
+    [name: string]: string
+  },
   options?: Options
 ): UseRichTextEditorReturnValue {
   options = {


### PR DESCRIPTION
I've used this hook for the `RichTextContent` component, which doesn't make sense to have a label.