### PR TITLE
Force a release due to pipeline issue

### DIFF
--- a/.changeset/spicy-cats-own.md
+++ b/.changeset/spicy-cats-own.md
@@ -1,0 +1,5 @@
+---
+"@cultureamp/rich-text-toolkit": patch
+---
+
+Force a release due to pipeline issue


### PR DESCRIPTION
There was never a release PR triggered for https://github.com/cultureamp/rich-text-toolkit/pull/41, so trying another release to see if that works.