### PR TITLE
feat: Fix `listIsActive` method for nested lists of different types

### DIFF
--- a/.changeset/big-insects-serve.md
+++ b/.changeset/big-insects-serve.md
@@ -1,0 +1,5 @@
+---
+"@cultureamp/rich-text-toolkit": minor
+---
+
+Fix listIsActive helper for nested lists

--- a/src/commands/listIsActive.ts
+++ b/src/commands/listIsActive.ts
@@ -1,10 +1,16 @@
 import { EditorState } from "prosemirror-state"
 import { NodeType, Schema } from "prosemirror-model"
-import { hasParentNodeOfType } from "prosemirror-utils"
+import { findParentNodeOfTypeClosestToPos } from "prosemirror-utils"
 
 export function listIsActive(
   state: EditorState,
-  type: NodeType<Schema<any, any>>
+  type: NodeType<Schema<any, any>>,
+  listNodes: typeof type[]
 ) {
-  return hasParentNodeOfType(state.schema.nodes[type.name])(state.selection)
+  const listNode = findParentNodeOfTypeClosestToPos(
+    state.selection.$from,
+    listNodes
+  )
+
+  return listNode?.node.type === type
 }


### PR DESCRIPTION
- Use `findParentNodeOfType` to find nearest parent list item. This lets us know which list type is active nearest when bullet and ordered lists are nested
- Add `listNodes` array, which passes schema used for lists in the RTE